### PR TITLE
Clarify default Scene hooks

### DIFF
--- a/src/game_engine/scene.py
+++ b/src/game_engine/scene.py
@@ -7,6 +7,14 @@ class Scene:
     def __init__(self, name: str = "Scene"):
         self.name = name
 
+    def on_enter(self) -> None:
+        """Default no-op hook when the scene is pushed; override to react."""
+        pass
+
+    def render(self) -> None:
+        """Default no-op render hook; override to draw the active scene."""
+        pass
+
     def on_exit(self) -> None:
         pass
 


### PR DESCRIPTION
## Summary
- explain that Scene.on_enter is a default no-op when a scene is pushed and note it can be overridden to react
- explain that Scene.render is a default no-op when GameApp draws the scene and note it can be overridden to draw custom content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca304b99f08327a34aa5cb9fe53ca6