### PR TITLE
Use app input provider in TextScene

### DIFF
--- a/src/game_engine/scene.py
+++ b/src/game_engine/scene.py
@@ -56,7 +56,12 @@ class TextScene(Scene):
         # Liest Benutzereingabe und verarbeitet sie, falls process_command existiert
         if hasattr(self, "process_command"):
             # Farbiges Prompt
-            user_input = input(f"{self.color}{self.prompt}\033[0m ")
+            prompt = f"{self.color}{self.prompt}\033[0m "
+            app = getattr(self, "app", None)
+            if app is not None:
+                user_input = app.get_input(prompt)
+            else:
+                user_input = input(prompt)
             self.process_command(user_input)
             return True
         print(f"{self.color}[DEBUG] process_command nicht vorhanden\033[0m")


### PR DESCRIPTION
## Summary
- update TextScene handle_input to prefer the hosting GameApp's input provider
- keep ANSI-formatted prompts when collecting user commands

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca38013a508327b2a2efa6a7e6d592