### PR TITLE
Fix typing annotations for Python 3.8 compatibility

### DIFF
--- a/examples/lantern_maze.py
+++ b/examples/lantern_maze.py
@@ -232,7 +232,7 @@ class LanternMazeScene(TextScene):
                     neigh.append((nx, ny))
         return neigh
 
-    def _find_dead_ends(self) -> set[Position]:
+    def _find_dead_ends(self) -> Set[Position]:
         dead = set()
         for y in range(self.height):
             for x in range(self.width):


### PR DESCRIPTION
## Summary
- replace the `_find_dead_ends` return annotation with `Set[Position]`
- ensure the module consistently uses typing generics compatible with Python 3.8

## Testing
- python -m compileall examples/lantern_maze.py

------
https://chatgpt.com/codex/tasks/task_e_68ca380285788327ab1c47176cfd02b1