### PR TITLE
Fix TextScene handle_input fallback

### DIFF
--- a/src/game_engine/scene.py
+++ b/src/game_engine/scene.py
@@ -64,8 +64,11 @@ class TextScene(Scene):
                 user_input = input(prompt)
             self.process_command(user_input)
             return True
-        print(f"{self.color}[DEBUG] process_command nicht vorhanden\033[0m")
-        return False
+        print(
+            f"{self.color}[DEBUG] process_command nicht vorhanden,"
+            f" delegiere an Scene.handle_input()\033[0m"
+        )
+        return super().handle_input()
 
     def update(self, delta_time: float) -> None:
         # Standardmäßig keine Logik, kann von Kindklassen überschrieben werden

--- a/tests/test_text_scene.py
+++ b/tests/test_text_scene.py
@@ -1,0 +1,30 @@
+"""Tests for TextScene input handling."""
+
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from game_engine.scene import TextScene
+
+
+class SimpleTextScene(TextScene):
+    """Minimal TextScene subclass without process_command."""
+
+    def get_display_text(self) -> str:
+        return "Simple display text"
+
+
+def test_text_scene_handle_input_without_process_command(capsys):
+    """TextScene without process_command should still proceed."""
+
+    scene = SimpleTextScene(name="NoCmdScene")
+
+    result = scene.handle_input()
+    captured = capsys.readouterr().out
+
+    assert "[DEBUG] process_command nicht vorhanden" in captured
+    assert result is True


### PR DESCRIPTION
## Summary
- update TextScene.handle_input to delegate to the base Scene handler when no process_command is defined
- log a more descriptive diagnostic when falling back so the game loop can continue updating and rendering
- add a regression test covering a TextScene subclass without process_command to ensure the fallback path stays functional

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca3efc81f88327b80ac576381d4256