### PR TITLE
Validate lantern maze start/exit before BFS

### DIFF
--- a/examples/lantern_maze.py
+++ b/examples/lantern_maze.py
@@ -108,8 +108,11 @@ class LanternMazeScene(TextScene):
                     elif tile == "E":
                         self.exit = (x, y)
             self._layout.append(row_tiles)
+        if self.start is None or self.exit is None:
+            raise ValueError("Map must define both a start (P) and exit (E) tile.")
         # Erreichbare Felder berechnen (Flood-Fill/BFS)
         from collections import deque
+
         def reachable_from(start):
             visited = set()
             queue = deque([start])
@@ -119,8 +122,8 @@ class LanternMazeScene(TextScene):
                     continue
                 visited.add(pos)
                 x, y = pos
-                for dx, dy in [(-1,0),(1,0),(0,-1),(0,1)]:
-                    nx, ny = x+dx, y+dy
+                for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+                    nx, ny = x + dx, y + dy
                     if 0 <= nx < self.width and 0 <= ny < self.height:
                         if self._layout[ny][nx] == "#":
                             continue
@@ -128,10 +131,9 @@ class LanternMazeScene(TextScene):
                         if npos not in visited:
                             queue.append(npos)
             return visited
+
         reachable = reachable_from(self.start)
         self._reachable_positions = reachable - {self.start, self.exit}
-        if self.start is None or self.exit is None:
-            raise ValueError("Map must define both a start (P) and exit (E) tile.")
         if self.exit not in reachable:
             raise ValueError("Exit is not reachable from start! Please check the map layout.")
         self.total_torches = num_torches

--- a/tests/test_lantern_maze.py
+++ b/tests/test_lantern_maze.py
@@ -1,0 +1,35 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def lantern_maze_module():
+    module_name = "tests.examples.lantern_maze"
+    module_path = Path(__file__).resolve().parents[1] / "examples" / "lantern_maze.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load lantern_maze module for testing.")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    try:
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+@pytest.mark.parametrize(
+    "blueprint",
+    [
+        ("###", "#E#", "###"),
+        ("###", "#P#", "###"),
+    ],
+    ids=["missing-start", "missing-exit"],
+)
+def test_missing_required_tiles_raise_value_error(monkeypatch, lantern_maze_module, blueprint):
+    monkeypatch.setattr(lantern_maze_module, "MAP_BLUEPRINT", blueprint)
+    with pytest.raises(ValueError, match=r"Map must define both a start \(P\) and exit \(E\) tile\."):
+        lantern_maze_module.LanternMazeScene()


### PR DESCRIPTION
## Summary
- ensure LanternMazeScene validates that both start and exit tiles exist before computing reachability
- maintain reachability calculation and unreachable exit guard after the validation
- add a pytest verifying that malformed maps raise the expected ValueError

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca3efe79d48327b15be31dc94ca918