### PR TITLE
Remove stray text in custom games section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,6 @@ python examples/first_game.py
 
 ## 🕹️ Eigene Spiele erstellen
 
-dio).
-
 1. **Umgebung aufsetzen:** Erweitere die Basisklassen (`GameApp`, `Scene` etc.) für dein Spiel.
 2. **Gameplay designen:** Füge Objekte und Logik mit den Modulsystemen hinzu (Physik, Rendering, Audio ...).
 3. **Testen & Spaß haben:** Starte dein Spiel und bring deine Ideen zum Leben!


### PR DESCRIPTION
## Summary
- remove a stray fragment under the custom games section heading so the list follows the header directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca52bf48988327b5b0377df0be0b5b