### PR TITLE
Add TextScene handle_input test with fake GameApp

### DIFF
--- a/tests/test_text_scene.py
+++ b/tests/test_text_scene.py
@@ -11,6 +11,34 @@ if str(SRC_DIR) not in sys.path:
 from game_engine.scene import TextScene
 
 
+class FakeGameApp:
+    """Stubbed GameApp collecting prompts and returning scripted commands."""
+
+    def __init__(self, scripted_commands):
+        self.scripted_commands = list(scripted_commands)
+        self.prompts = []
+
+    def get_input(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        if not self.scripted_commands:
+            raise AssertionError("No scripted commands remaining for get_input")
+        return self.scripted_commands.pop(0)
+
+
+class RecordingTextScene(TextScene):
+    """TextScene subclass that records commands passed to process_command."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.processed_commands = []
+
+    def get_display_text(self) -> str:
+        return "Recording scene display"
+
+    def process_command(self, command: str) -> None:
+        self.processed_commands.append(command)
+
+
 class SimpleTextScene(TextScene):
     """Minimal TextScene subclass without process_command."""
 
@@ -27,4 +55,19 @@ def test_text_scene_handle_input_without_process_command(capsys):
     captured = capsys.readouterr().out
 
     assert "[DEBUG] process_command nicht vorhanden" in captured
+    assert result is True
+
+
+def test_text_scene_handle_input_with_fake_app():
+    """TextScene handle_input uses GameApp stub and forwards command."""
+
+    fake_app = FakeGameApp(scripted_commands=["look around"])
+    scene = RecordingTextScene(name="CmdScene")
+    scene.app = fake_app
+
+    result = scene.handle_input()
+
+    expected_prompt = f"{scene.color}{scene.prompt}\033[0m "
+    assert fake_app.prompts == [expected_prompt]
+    assert scene.processed_commands == ["look around"]
     assert result is True


### PR DESCRIPTION
## Summary
- add a FakeGameApp stub to drive TextScene input without real user interaction
- create a RecordingTextScene subclass to capture processed commands
- expand tests to validate prompt colouring, command forwarding, and return value from handle_input

## Testing
- pytest tests/test_text_scene.py

------
https://chatgpt.com/codex/tasks/task_e_68ca52c49e8c832781539858d3462cdd