### PR TITLE
Handle dense crystal layouts in first game

### DIFF
--- a/examples/first_game.py
+++ b/examples/first_game.py
@@ -98,8 +98,13 @@ class CrystalCollectorScene(TextScene):
         forbidden = {self.player}
         self.crystals = self._spawn_positions(self.total_crystals, forbidden)
         forbidden = forbidden | self.crystals
-        hazard_count = max(1, self.total_crystals // 2)
-        self.hazards = self._spawn_positions(hazard_count, forbidden)
+        available_tiles = self.width * self.height - len(forbidden)
+        hazard_target = max(1, self.total_crystals // 2)
+        hazard_count = min(hazard_target, available_tiles)
+        if hazard_count == 0:
+            self.hazards = set()
+        else:
+            self.hazards = self._spawn_positions(hazard_count, forbidden)
 
         self.message = "Collect all crystals before your energy runs out!"
 

--- a/tests/test_first_game.py
+++ b/tests/test_first_game.py
@@ -1,0 +1,34 @@
+"""Tests for the Crystal Collector example game."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FIRST_GAME_PATH = PROJECT_ROOT / "examples" / "first_game.py"
+
+
+def _load_first_game_module():
+    module_name = "examples.first_game"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    spec = importlib.util.spec_from_file_location(module_name, FIRST_GAME_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_dense_crystal_layout_initializes():
+    first_game = _load_first_game_module()
+    scene = first_game.CrystalCollectorScene(width=3, height=3, crystals=8, energy=5, seed=123)
+
+    # Ensure the board can be reset without triggering placement errors.
+    scene.reset_board()
+
+    assert len(scene.crystals) == 8
+    assert len(scene.hazards) == 0


### PR DESCRIPTION
## Summary
- prevent hazard spawning when no tiles remain after placing crystals
- ensure hazard placement respects available tiles in the Crystal Collector scene
- add regression test covering dense crystal layouts on a small board

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca52c4dd7c832799aeb342bce1ffb0