### PR TITLE
Ensure scenes initialise app reference before use

### DIFF
--- a/examples/lantern_maze.py
+++ b/examples/lantern_maze.py
@@ -109,11 +109,13 @@ class LanternMazeScene(TextScene):
         num_traps: int = 2,
         rng_seed: Optional[int] = None,
     ) -> None:
-        self.prompt = "Move:"
-        self.border = True
-        self.color = "\033[95m"  # Lila
-        self.icon = "\U0001F56F"  # Laterne-Emoji
-        self.name = "Lantern Maze"
+        super().__init__(
+            name="Lantern Maze",
+            prompt="Move:",
+            color="\033[95m",  # Lila
+            border=True,
+            icon="\U0001F56F",  # Laterne-Emoji
+        )
         self._last_move = None
         self.view_radius = view_radius
         self.num_torches = num_torches

--- a/src/game_engine/scene.py
+++ b/src/game_engine/scene.py
@@ -1,11 +1,15 @@
-# scene.py
-# Platzhalter für Scene-Klasse oder verwandte Logik
+from __future__ import annotations
 
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from .app import GameApp
 
 
 class Scene:
     def __init__(self, name: str = "Scene"):
         self.name = name
+        self.app: Optional[GameApp] = None
 
     def on_enter(self) -> None:
         """Hook invoked when the scene is pushed onto a GameApp; override if needed."""
@@ -25,7 +29,14 @@ class Scene:
         pass
 
 class TextScene(Scene):
-    def __init__(self, name: str = "TextScene", prompt: str = "> ", color: str = "\033[96m", border: bool = True, icon: str = "🕹️"):
+    def __init__(
+        self,
+        name: str = "TextScene",
+        prompt: str = "> ",
+        color: str = "\033[96m",
+        border: bool = True,
+        icon: str = "🕹️",
+    ):
         super().__init__(name=name)
         self.prompt = prompt
         self.color = color  # ANSI-Farbe für Szenentitel/Text
@@ -57,7 +68,7 @@ class TextScene(Scene):
         if hasattr(self, "process_command"):
             # Farbiges Prompt
             prompt = f"{self.color}{self.prompt}\033[0m "
-            app = getattr(self, "app", None)
+            app = self.app
             if app is not None:
                 user_input = app.get_input(prompt)
             else:

--- a/tests/test_lantern_maze.py
+++ b/tests/test_lantern_maze.py
@@ -52,6 +52,20 @@ def test_missing_required_tiles_raise_value_error(monkeypatch, lantern_maze_modu
         lantern_maze_module.LanternMazeScene()
 
 
+def test_process_command_without_app_raises_runtime_error(lantern_maze_module):
+    scene = lantern_maze_module.LanternMazeScene()
+
+    with pytest.raises(RuntimeError, match=r"Scene is not attached to an application\."):
+        scene.process_command("h")
+
+
+def test_hint_without_app_raises_runtime_error(lantern_maze_module):
+    scene = lantern_maze_module.LanternMazeScene()
+
+    with pytest.raises(RuntimeError, match=r"Scene is not attached to an application\."):
+        scene._hint()
+
+
 def test_exploring_new_tile_awards_points(lantern_maze_module):
     scene = lantern_maze_module.LanternMazeScene(num_torches=0, num_traps=0, rng_seed=1)
     scene.app = DummyApp()


### PR DESCRIPTION
## Summary
- initialise the base Scene with an optional GameApp reference and rely on it in TextScene input handling
- ensure LanternMazeScene delegates to TextScene.__init__ so base initialisation always runs
- add regression coverage that LanternMazeScene surfaces a RuntimeError when used without an attached app

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca5a0a8098832788c41996080b8b0c