### PR TITLE
Route game output through injected handler

### DIFF
--- a/src/game_engine/app.py
+++ b/src/game_engine/app.py
@@ -82,16 +82,16 @@ class GameApp:
         self._running = False
 
     def run(self) -> None:
-        print("[DEBUG] GameApp.run() gestartet")
+        self.display("[DEBUG] GameApp.run() gestartet")
         if not self._scene_stack:
-            print("[DEBUG] Keine Szenen im Stack!")
+            self.display("[DEBUG] Keine Szenen im Stack!")
             raise RuntimeError("No scenes have been pushed onto the app.")
 
         self._running = True
         prev_time = time.perf_counter()
         first_scene = self.current_scene()
         if first_scene is not None:
-            print("[DEBUG] Erste Szene vorhanden, render() wird aufgerufen")
+            self.display("[DEBUG] Erste Szene vorhanden, render() wird aufgerufen")
             first_scene.render()
 
         try:

--- a/src/game_engine/scene.py
+++ b/src/game_engine/scene.py
@@ -34,23 +34,29 @@ class TextScene(Scene):
 
     def render(self) -> None:
         # Bildschirm löschen (funktioniert in den meisten Terminals)
-        print("\033[2J\033[H", end="")
+        app = getattr(self, "app", None)
+        if app is not None:
+            output = app.display
+            output("\033[2J\033[H")
+        else:
+            output = print
+            print("\033[2J\033[H", end="")
         # Szenentitel mit Farbe und Icon
         title = f"{self.color}{self.icon} {self.name} {self.icon}\033[0m"
         if self.border:
             border_line = f"{self.color}" + "═" * (len(self.name) + 8) + "\033[0m"
-            print(border_line)
-            print(title)
-            print(border_line)
+            output(border_line)
+            output(title)
+            output(border_line)
         else:
-            print(title)
+            output(title)
         # Szenentext
         if hasattr(self, "get_display_text"):
             text = self.get_display_text()
             # Optional: Text farbig
-            print(f"{self.color}{text}\033[0m")
+            output(f"{self.color}{text}\033[0m")
         else:
-            print(f"{self.color}[DEBUG] get_display_text nicht vorhanden\033[0m")
+            output(f"{self.color}[DEBUG] get_display_text nicht vorhanden\033[0m")
 
     def handle_input(self) -> bool:
         # Liest Benutzereingabe und verarbeitet sie, falls process_command existiert

--- a/tests/test_text_scene.py
+++ b/tests/test_text_scene.py
@@ -71,3 +71,22 @@ def test_text_scene_handle_input_with_fake_app():
     assert fake_app.prompts == [expected_prompt]
     assert scene.processed_commands == ["look around"]
     assert result is True
+
+
+def test_text_scene_render_uses_app_display(capsys):
+    output_messages = []
+
+    class DisplayingApp:
+        def display(self, message: str) -> None:
+            output_messages.append(message)
+
+    scene = SimpleTextScene(name="RenderScene")
+    scene.app = DisplayingApp()
+
+    scene.render()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert output_messages[0] == "\033[2J\033[H"
+    assert output_messages[-1] == f"{scene.color}{scene.get_display_text()}\033[0m"
+    assert all(isinstance(message, str) for message in output_messages)


### PR DESCRIPTION
## Summary
- route GameApp debug output through the injected display handler
- update TextScene rendering to honour an attached app output handler
- extend unit tests to cover custom output injection and TextScene rendering

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca5a0b070c8327942426dcc9ebc62a