### PR TITLE
Add raw input support to GameApp and test arrow key sequences

### DIFF
--- a/examples/lantern_maze.py
+++ b/examples/lantern_maze.py
@@ -565,7 +565,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Optional[Sequence[str]] = None) -> None:
     args = build_parser().parse_args(argv)
     scene = LanternMazeScene(view_radius=args.view_radius, num_torches=args.torches, num_traps=args.traps)
-    app = GameApp()
+    app = GameApp(use_raw_input=True)
     app.push_scene(scene)
     app.run()
 


### PR DESCRIPTION
## Summary
- add helpers that enable raw input in `GameApp`, including POSIX and Windows reader implementations
- opt the lantern maze example into the raw input provider when available
- extend the lantern maze tests to cover arrow-key escape sequences routed through `GameApp`

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca5e6a76648327aa2672232f8ea165